### PR TITLE
Change version datatype

### DIFF
--- a/Code/FMDBMigrationManager.h
+++ b/Code/FMDBMigrationManager.h
@@ -77,13 +77,13 @@
  @abstract Returns the current version of the database managed by the receiver or `0` if the
  migrations table is not present.
  */
-@property (nonatomic, readonly) uint64_t currentVersion;
+@property (nonatomic, readonly) int64_t currentVersion;
 
 /**
  @abstract Returns the origin version of the database managed by the receiver or `0` if the
  migrations table is not present.
  */
-@property (nonatomic, readonly) uint64_t originVersion;
+@property (nonatomic, readonly) int64_t originVersion;
 
 ///---------------------------
 /// @name Accessing Migrations
@@ -116,7 +116,7 @@
  @param version The version of the desired migration.
  @return A migration with the specified version or `nil` if none could be found.
  */
-- (id<FMDBMigrating>)migrationForVersion:(uint64_t)version;
+- (id<FMDBMigrating>)migrationForVersion:(int64_t)version;
 
 /**
  @abstract Returns a migration object with a given name or `nil` if none could be found.
@@ -160,7 +160,7 @@
  @param error A pointer to an error object that is set upon failure to complete the migrations.
  @return `YES` if migration was successful, else `NO`.
  */
-- (BOOL)migrateDatabaseToVersion:(uint64_t)version progress:(void (^)(NSProgress *progress))progressBlock error:(NSError **)error;
+- (BOOL)migrateDatabaseToVersion:(int64_t)version progress:(void (^)(NSProgress *progress))progressBlock error:(NSError **)error;
 
 @end
 
@@ -180,14 +180,14 @@
 /**
  @abstract The name of the migration.
  */
-@property (nonatomic, readonly) NSString *name;
+@property (nonatomic, copy, readonly) NSString *name;
 
 /**
  @abstract The numeric version of the migration. 
  @discussion While monotonically incremented versions are fully supported, it is recommended that to use a timestamp format such as
  201406063106474. Timestamps avoid unnecessary churn in a codebase that is heavily branched.
  */
-@property (nonatomic, readonly) uint64_t version;
+@property (nonatomic, readonly) int64_t version;
 
 ///--------------------------
 /// @name Migrating Databases
@@ -226,12 +226,12 @@
 /**
  @abstract The path to the SQL migration file on disk.
  */
-@property (nonatomic, readonly) NSString *path;
+@property (nonatomic, copy, readonly) NSString *path;
 
 /**
  @abstract A convenience accessor for retrieving the SQL from the receiver's path.
  */
-@property (nonatomic, readonly) NSString *SQL;
+@property (nonatomic, copy, readonly) NSString *SQL;
 
 @end
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Objective-C based migrations can be implemented by creating a new class that con
     return @"My Object Migration";
 }
 
-- (uint64_t)version
+- (int64_t)version
 {
     return 201499000000000;
 }
@@ -150,7 +150,7 @@ When classes conforming to the `FMDBMigrating` protocol are added to the project
 ```objc
 FMDBMigrationManager *manager = [FMDBMigrationManager managerWithDatabaseAtPath:@"path/to/your/DB.sqlite" migrationsBundle:[NSBundle mainBundle]];
 NSError *error = nil;
-BOOL success = [manager migrateDatabaseToVersion:UINT64_MAX progress:nil error:&error];
+BOOL success = [manager migrateDatabaseToVersion:INT64_MAX progress:nil error:&error];
 ```
 
 ### Inspecting Schema State

--- a/Tests/FMDBMigrationManagerTests.m
+++ b/Tests/FMDBMigrationManagerTests.m
@@ -67,7 +67,7 @@ static FMDatabase *FMDatabaseWithSchemaMigrationsTable()
     return @"My Object Migration";
 }
 
-- (uint64_t)version
+- (int64_t)version
 {
     return 201499000000000;
 }
@@ -307,7 +307,7 @@ static FMDatabase *FMDatabaseWithSchemaMigrationsTable()
     FMDBMigrationManager *manager = [FMDBMigrationManager managerWithDatabaseAtPath:FMDBRandomDatabasePath() migrationsBundle:FMDBMigrationsTestBundle()];
     expect(manager.hasMigrationsTable).to.beFalsy();
     NSError *error = nil;
-    BOOL success = [manager migrateDatabaseToVersion:UINT64_MAX progress:nil error:&error];
+    BOOL success = [manager migrateDatabaseToVersion:INT64_MAX progress:nil error:&error];
     expect(success).to.beTruthy();
     expect(error).to.beNil();
     expect(manager.hasMigrationsTable).to.beTruthy();
@@ -320,7 +320,7 @@ static FMDatabase *FMDatabaseWithSchemaMigrationsTable()
     FMDBMigrationManager *manager = [FMDBMigrationManager managerWithDatabase:database migrationsBundle:FMDBMigrationsTestBundle()];
     expect(manager.hasMigrationsTable).to.beFalsy();
     NSError *error = nil;
-    BOOL success = [manager migrateDatabaseToVersion:UINT64_MAX progress:nil error:&error];
+    BOOL success = [manager migrateDatabaseToVersion:INT64_MAX progress:nil error:&error];
     expect(success).to.beTruthy();
     expect(error).to.beNil();
     expect(manager.hasMigrationsTable).to.beTruthy();
@@ -344,7 +344,7 @@ static FMDatabase *FMDatabaseWithSchemaMigrationsTable()
     FMDBMigrationManager *manager = [FMDBMigrationManager managerWithDatabaseAtPath:FMDBRandomDatabasePath() migrationsBundle:FMDBMigrationsTestBundle()];
     expect(manager.hasMigrationsTable).to.beFalsy();
     NSError *error = nil;
-    BOOL success = [manager migrateDatabaseToVersion:UINT64_MAX progress:^(NSProgress *progress) {
+    BOOL success = [manager migrateDatabaseToVersion:INT64_MAX progress:^(NSProgress *progress) {
         if ([progress.userInfo[@"version"] isEqualToNumber:@201406063548463]) {
             [progress cancel];
         }


### PR DESCRIPTION
Hi,

I'd like to change the version datatype from `uint64_t` to `int64_t`, because:
- There is no `scanUnsignedLongLong` method on `NSScanner` before Mavericks (Yesterday I ran into a bug "unrecognized selector sent to.." on Mountain Lion. Although I set the deployment target to 10.8, Xcode did not warn me about that method not being available on 10.8.. Worked fine on my 10.10 machine but not on my customers 10.8 iMac)
- The SQLite datatype INTEGER is signed
- 9.2 x 10^18 (INT64_MAX) should be more than enough for version numbers

I also changed the tests and the README. Everything passing and working fine both on Yosemite and Mountain Lion.

I hope my changes are not too intrusive? I added `copy` to `NSString*` property declarations as recommended by Apple.

I also added a fix for backwards compatibility, because many users will most likely use the suggested `migrateDatabaseToVersion:UINT64_MAX`. In that case I just set version to `INT64_MAX` instead so it will continue to work without having to change user code.

What do you think?

Regards, Clemens