### PR TITLE
Fix unrecognized selector bug on OS X 10.8

### DIFF
--- a/Code/FMDBMigrationManager.m
+++ b/Code/FMDBMigrationManager.m
@@ -302,8 +302,8 @@ static BOOL FMDBMigrationScanMetadataFromPath(NSString *path, uint64_t *version,
     NSTextCheckingResult *result = [regex firstMatchInString:migrationName options:0 range:NSMakeRange(0, [migrationName length])];
     if ([result numberOfRanges] != 3) return NO;
     NSString *versionString = [migrationName substringWithRange:[result rangeAtIndex:1]];
-    NSScanner *scanner = [NSScanner scannerWithString:versionString];
-    [scanner scanUnsignedLongLong:version];
+    if(!versionString) return NO;
+    *version = strtoull([versionString UTF8String], NULL, 10);
     NSRange range = [result rangeAtIndex:2];
     *name = (range.length) ? [migrationName substringWithRange:[result rangeAtIndex:2]] : nil;
     return YES;


### PR DESCRIPTION
Use the more portable `strtoull` instead of `scanUnsignedLongLong`. The latter is not available in OS X 10.8 and leads to a "unrecognized selector" bug. Xcode does not warn about that (in 10.8) unknown function, even if you set 10.8 as Deployment Target.

It's probably a better solution than my (unanswered and now closed) PR to change the version datatype.

By the way: Somebody should fix the Podfile.lock for the travis builds.. it has been messed up with a CocoaPods beta version and has not been updated after the last version bump.

Signed-off-by: Clemens Gruber <clemensgru@gmail.com>