### PR TITLE
Fixed letter casing of imports

### DIFF
--- a/Code/FMDBMigrationManager.h
+++ b/Code/FMDBMigrationManager.h
@@ -18,8 +18,8 @@
 //  limitations under the License.
 //
 
-#import <fmdb/FMDatabase.h>
-#import <fmdb/FMDatabaseQueue.h>
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 @protocol FMDBMigrating;
 

--- a/Tests/FMDBMigrationManagerTests.m
+++ b/Tests/FMDBMigrationManagerTests.m
@@ -9,7 +9,7 @@
 #import <XCTest/XCTest.h>
 #define EXP_SHORTHAND
 #import "Expecta.h"
-#import "FMDBmigrationManager.h"
+#import "FMDBMigrationManager.h"
 
 static NSString *FMDBApplicationDataDirectory(void)
 {


### PR DESCRIPTION
- This issue was causing build errors on case sensitive file systems