### PR TITLE
update Podfile for the new version CocoaPods 1.1.0.beta

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-xcodeproj 'Tests/FMDBMigrationManagerTests'
+project 'Tests/FMDBMigrationManagerTests'
 workspace 'FMDBMigrationManager'
 
 def import_pods
@@ -7,14 +7,12 @@ def import_pods
   pod 'FMDBMigrationManager', :path => '.'
 end
 
-target :ios do
+target :'iOS Tests' do
   platform :ios, '7.0'
-  link_with 'iOS Tests'
   import_pods
 end
 
-target :osx do
+target :'OS X Tests' do
   platform :osx, '10.9'
-  link_with 'OS X Tests'
   import_pods
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Expecta (0.3.2)
-  - FMDB/common (2.5)
-  - FMDB/standard (2.5):
-    - FMDB/common
-  - FMDBMigrationManager (1.3.5):
-    - FMDB/common (>= 2.3)
+  - FMDB/standard (2.6.2)
+  - FMDBMigrationManager (1.4.1):
+    - FMDBMigrationManager/System (= 1.4.1)
+  - FMDBMigrationManager/System (1.4.1):
+    - FMDB/standard (>= 2.3)
 
 DEPENDENCIES:
   - Expecta (~> 0.3.0)
@@ -17,7 +17,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
-  FMDB: 96e8f1bcc1329e269330f99770ad4285d9003e52
-  FMDBMigrationManager: 0b41192a3aa0f24497d8b162c108cc1296d19fb7
+  FMDB: 854a0341b4726e53276f2a8996f06f1b80f9259a
+  FMDBMigrationManager: d52007f328ea0665e8985ca8a33500707aef084f
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 61da09b650eb6600c18fd68ee285b37b7c6cc50e
+
+COCOAPODS: 1.0.1

--- a/README.md
+++ b/README.md
@@ -240,3 +240,6 @@ Blake Watters
 ## License
 
 FMDBMigrationManager is available under the Apache 2 License. See the LICENSE file for more info.
+
+## Update Podfile for CocoaPods 1.1.0beta
+Cause CocoaPods 1.1.0 syntax has changed (not support keyword:link_with, xcodeproj), so the Podfile must be update!

--- a/Tests/FMDBMigrationManagerTests.xcodeproj/project.pbxproj
+++ b/Tests/FMDBMigrationManagerTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AD5C5773FC18F97129691C7 /* libPods-iOS Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 737656972801F86452FE4A30 /* libPods-iOS Tests.a */; };
 		259697901942564500D1FA49 /* FMDBMigrationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 25FFD172194255D400F62FAF /* FMDBMigrationManagerTests.m */; };
 		25D1D1CD1943935F004D1098 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25FFD14C1942553B00F62FAF /* XCTest.framework */; };
 		25D1D1DA1943936F004D1098 /* FMDBMigrationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 25FFD172194255D400F62FAF /* FMDBMigrationManagerTests.m */; };
@@ -17,11 +18,12 @@
 		25FFD14D1942553B00F62FAF /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25FFD14C1942553B00F62FAF /* XCTest.framework */; };
 		25FFD14F1942553B00F62FAF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25FFD14E1942553B00F62FAF /* Foundation.framework */; };
 		25FFD1511942553B00F62FAF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25FFD1501942553B00F62FAF /* UIKit.framework */; };
-		3F270AFE6C1E4040AE6F0B74 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AF9CF4CAEAAD4C4CB25865FB /* libPods-osx.a */; };
-		49079291CD404940AE18D60E /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2300108E74444446931093DD /* libPods-ios.a */; };
+		EA0919662894F35CAB54F13C /* libPods-OS X Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B5E2AFD1F56F4DA99DE0659D /* libPods-OS X Tests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		00778306C405F1CE715DB1ED /* Pods-OS X Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.release.xcconfig"; sourceTree = "<group>"; };
+		10637885411A79328047E9B9 /* Pods-iOS Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Tests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests.release.xcconfig"; sourceTree = "<group>"; };
 		19114EB4C4CA8BE5BA74D12F /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		1C80E2CF6D0DC3E77EA66369 /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
 		2300108E74444446931093DD /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -35,9 +37,13 @@
 		25FFD172194255D400F62FAF /* FMDBMigrationManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FMDBMigrationManagerTests.m; sourceTree = "<group>"; };
 		25FFD173194255D400F62FAF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		25FFD174194255D400F62FAF /* Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = "<group>"; };
+		737656972801F86452FE4A30 /* libPods-iOS Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-iOS Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E64170A48AF6014ABFEE5D7 /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "../Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
 		AF9CF4CAEAAD4C4CB25865FB /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5E2AFD1F56F4DA99DE0659D /* libPods-OS X Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-OS X Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D34770AB47018BBD30CA12EC /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "../Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
+		DED528B6C37FAE006A582578 /* Pods-OS X Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		E979791CD1E2841F41211501 /* Pods-iOS Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS Tests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,7 +52,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				25D1D1CD1943935F004D1098 /* XCTest.framework in Frameworks */,
-				3F270AFE6C1E4040AE6F0B74 /* libPods-osx.a in Frameworks */,
+				EA0919662894F35CAB54F13C /* libPods-OS X Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,7 +63,7 @@
 				25FFD14D1942553B00F62FAF /* XCTest.framework in Frameworks */,
 				25FFD1511942553B00F62FAF /* UIKit.framework in Frameworks */,
 				25FFD14F1942553B00F62FAF /* Foundation.framework in Frameworks */,
-				49079291CD404940AE18D60E /* libPods-ios.a in Frameworks */,
+				1AD5C5773FC18F97129691C7 /* libPods-iOS Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,6 +101,8 @@
 				25FFD1501942553B00F62FAF /* UIKit.framework */,
 				2300108E74444446931093DD /* libPods-ios.a */,
 				AF9CF4CAEAAD4C4CB25865FB /* libPods-osx.a */,
+				B5E2AFD1F56F4DA99DE0659D /* libPods-OS X Tests.a */,
+				737656972801F86452FE4A30 /* libPods-iOS Tests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -106,6 +114,10 @@
 				7E64170A48AF6014ABFEE5D7 /* Pods-ios.release.xcconfig */,
 				1C80E2CF6D0DC3E77EA66369 /* Pods-osx.debug.xcconfig */,
 				D34770AB47018BBD30CA12EC /* Pods-osx.release.xcconfig */,
+				DED528B6C37FAE006A582578 /* Pods-OS X Tests.debug.xcconfig */,
+				00778306C405F1CE715DB1ED /* Pods-OS X Tests.release.xcconfig */,
+				E979791CD1E2841F41211501 /* Pods-iOS Tests.debug.xcconfig */,
+				10637885411A79328047E9B9 /* Pods-iOS Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -117,12 +129,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 25D1D1D71943935F004D1098 /* Build configuration list for PBXNativeTarget "OS X Tests" */;
 			buildPhases = (
-				8D8B343D7B7844E7BC5E4AD8 /* Check Pods Manifest.lock */,
+				8D8B343D7B7844E7BC5E4AD8 /* [CP] Check Pods Manifest.lock */,
 				25D1D1C81943935F004D1098 /* Sources */,
 				25D1D1C91943935F004D1098 /* Frameworks */,
 				25D1D1CA1943935F004D1098 /* Resources */,
-				93F9B466CB6645238BB693BB /* Copy Pods Resources */,
-				23D16B0FBC6C4537A0AE180E /* Embed Pods Frameworks */,
+				93F9B466CB6645238BB693BB /* [CP] Copy Pods Resources */,
+				23D16B0FBC6C4537A0AE180E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -137,12 +149,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 25FFD15D1942553B00F62FAF /* Build configuration list for PBXNativeTarget "iOS Tests" */;
 			buildPhases = (
-				3876992AD7244EE9BD246C78 /* Check Pods Manifest.lock */,
+				3876992AD7244EE9BD246C78 /* [CP] Check Pods Manifest.lock */,
 				25FFD1451942553B00F62FAF /* Sources */,
 				25FFD1461942553B00F62FAF /* Frameworks */,
 				25FFD1471942553B00F62FAF /* Resources */,
-				EB341B975BC14C9C9C33AF40 /* Copy Pods Resources */,
-				49E110F3C0FD35FD85FAA91A /* Embed Pods Frameworks */,
+				EB341B975BC14C9C9C33AF40 /* [CP] Copy Pods Resources */,
+				49E110F3C0FD35FD85FAA91A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -201,29 +213,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		23D16B0FBC6C4537A0AE180E /* Embed Pods Frameworks */ = {
+		23D16B0FBC6C4537A0AE180E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3876992AD7244EE9BD246C78 /* Check Pods Manifest.lock */ = {
+		3876992AD7244EE9BD246C78 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -231,29 +243,29 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		49E110F3C0FD35FD85FAA91A /* Embed Pods Frameworks */ = {
+		49E110F3C0FD35FD85FAA91A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8D8B343D7B7844E7BC5E4AD8 /* Check Pods Manifest.lock */ = {
+		8D8B343D7B7844E7BC5E4AD8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -261,34 +273,34 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		93F9B466CB6645238BB693BB /* Copy Pods Resources */ = {
+		93F9B466CB6645238BB693BB /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EB341B975BC14C9C9C33AF40 /* Copy Pods Resources */ = {
+		EB341B975BC14C9C9C33AF40 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-iOS Tests/Pods-iOS Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -315,7 +327,7 @@
 /* Begin XCBuildConfiguration section */
 		25D1D1D81943935F004D1098 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1C80E2CF6D0DC3E77EA66369 /* Pods-osx.debug.xcconfig */;
+			baseConfigurationReference = DED528B6C37FAE006A582578 /* Pods-OS X Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -362,7 +374,7 @@
 		};
 		25D1D1D91943935F004D1098 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D34770AB47018BBD30CA12EC /* Pods-osx.release.xcconfig */;
+			baseConfigurationReference = 00778306C405F1CE715DB1ED /* Pods-OS X Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -417,7 +429,7 @@
 		};
 		25FFD15B1942553B00F62FAF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 19114EB4C4CA8BE5BA74D12F /* Pods-ios.debug.xcconfig */;
+			baseConfigurationReference = E979791CD1E2841F41211501 /* Pods-iOS Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -465,7 +477,7 @@
 		};
 		25FFD15C1942553B00F62FAF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7E64170A48AF6014ABFEE5D7 /* Pods-ios.release.xcconfig */;
+			baseConfigurationReference = 10637885411A79328047E9B9 /* Pods-iOS Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";


### PR DESCRIPTION
Cause CocoaPods 1.1.0 syntax has changed (not support keyword:link_with, xcodeproj), so the Podfile must be update!