### PR TITLE
isSubclassOfClass doesn't work sometimes

### DIFF
--- a/Code/FMDBMigrationManager.m
+++ b/Code/FMDBMigrationManager.m
@@ -219,7 +219,12 @@ static NSArray *FMDBClassesConformingToProtocol(Protocol *protocol)
     if (self.dynamicMigrationsEnabled) {
         NSArray *conformingClasses = FMDBClassesConformingToProtocol(@protocol(FMDBMigrating));
         for (Class migrationClass in conformingClasses) {
-            if ([migrationClass isSubclassOfClass:[FMDBFileMigration class]]) continue;
+            if ([name isEqualToString:NSStringFromClass ([FMDBFileMigration class])]) {
+                continue;
+            }
+            if ([migrationClass isSubclassOfClass:[FMDBFileMigration class]]){
+                 continue;
+            }
             id<FMDBMigrating> migration = [migrationClass new];
             [migrations addObject:migration];
         }

--- a/Code/FMDBMigrationManager.m
+++ b/Code/FMDBMigrationManager.m
@@ -219,7 +219,7 @@ static NSArray *FMDBClassesConformingToProtocol(Protocol *protocol)
     if (self.dynamicMigrationsEnabled) {
         NSArray *conformingClasses = FMDBClassesConformingToProtocol(@protocol(FMDBMigrating));
         for (Class migrationClass in conformingClasses) {
-            if (NSStringFromClass(migrationClass) isEqualToString:NSStringFromClass ([FMDBFileMigration class])]) {
+            if ([NSStringFromClass(migrationClass) isEqualToString:NSStringFromClass ([FMDBFileMigration class])]) {
                 continue;
             }
             if ([migrationClass isSubclassOfClass:[FMDBFileMigration class]]){

--- a/Code/FMDBMigrationManager.m
+++ b/Code/FMDBMigrationManager.m
@@ -219,7 +219,7 @@ static NSArray *FMDBClassesConformingToProtocol(Protocol *protocol)
     if (self.dynamicMigrationsEnabled) {
         NSArray *conformingClasses = FMDBClassesConformingToProtocol(@protocol(FMDBMigrating));
         for (Class migrationClass in conformingClasses) {
-            if ([name isEqualToString:NSStringFromClass ([FMDBFileMigration class])]) {
+            if (NSStringFromClass(migrationClass) isEqualToString:NSStringFromClass ([FMDBFileMigration class])]) {
                 continue;
             }
             if ([migrationClass isSubclassOfClass:[FMDBFileMigration class]]){


### PR DESCRIPTION
In some occasions we have encountered that even though the Class in the array is a FMDBFileMigration, it goes to the initialization of the migration, even though it's not supposed to. The only way we could prevent this from happening is by checking if the name of the class in the array is not FMDBFileMigration.